### PR TITLE
ARGO-298 removed a few references to egi tenant

### DIFF
--- a/etc/html/ar_custom_form.html
+++ b/etc/html/ar_custom_form.html
@@ -90,10 +90,10 @@
                             <div class="form-group ">
 
 
-
+<!--
                                 <label>NGI</label>
                                 <input type="text" style="margin-left:20px" name="ngi" id="filters-ngi" placeholder="Enter Search "/><br/>
-
+-->
 
 
 
@@ -122,9 +122,7 @@
                                <!--</select>-->
 
                                 <select name="report" id="report">
-                                    <option value="Critical" selected="true">EGI Critical Profile</option>
-                                    <option value="Cloud">EGI Cloud Profile</option>
-                                    <option value="OPS-MONITOR-Critical">EGI OPSMON profile</option>
+                                    <option value="B2HANDLE" selected="true">EUDAT B2HANDLE Profile</option>
                                 </select>
 
                             </div>

--- a/etc/html/recomputation.html
+++ b/etc/html/recomputation.html
@@ -72,9 +72,7 @@
                                             <!--</select>-->
 
                                     <select name="profile" id="profile" class="form-control">
-                                        <option value="Critical" selected="true">EGI Critical Profile</option>
-                                        <option value="Cloud">EGI Cloud Profile</option>
-                                        <option value="OPS-MONITOR-Critical">EGI OPSMON profile</option>
+                                        <option value="B2HANDLE" selected="true">EUDAT B2HANDLE Profile</option>
                                     </select>
 
                                 </div>

--- a/etc/html/status_form_reports.html
+++ b/etc/html/status_form_reports.html
@@ -103,13 +103,13 @@
 
 
 
-                                <label>OPERATIONS CENTER</label>
+                                <!--<label>OPERATIONS CENTER</label>
                                 <input type="text" style="margin-left:20px" name="ngi" id="filters-ngi" placeholder="Enter Search " /><br/>
+                                -->
 
 
 
-
-                                <label>SITE </label>
+                                <label>SITE</label>
                                 <input type="text" style="margin-left:20px" name="site" id="filters-site" placeholder="Enter Search " /><br/>
 
 
@@ -120,7 +120,7 @@
 
 
 
-                                <label>HOST </label>
+                                <label>HOST</label>
                                 <input type="text" style="margin-left:20px" name="host" id="filters-host" placeholder="Enter Search "/>
 
 
@@ -142,9 +142,7 @@
                                 <!--<input  tpl:foreach="/root/profile" tpl:with-order="@namespace" type="radio" class="profile" name="profile" value="{{concat(@namespace,'-',@name)}}" checked="true"> {{@poems}} <br/></input>-->
 
                                 <select name="report" id="report">
-                                    <option value="Critical" selected="true">EGI Critical Profile</option>
-                                    <option value="Cloud">EGI Cloud Profile</option>
-                                    <option value="OPS-MONITOR-Critical">EGI OPSMON profile</option>
+                                    <option value="B2HANDLE" selected="true">EUDAT B2HANDLE Profile</option>
                                 </select>
 
                             </div>


### PR DESCRIPTION
# Description

While browsing through the eudat portal noticed some references to tenant name in custom reports forms and recomputation request form. This fixes these references. 
