### PR TITLE
ARGO-311 Change url references to point to eudat gocdb pi

### DIFF
--- a/etc/argo-config.properties
+++ b/etc/argo-config.properties
@@ -48,7 +48,7 @@ api.monthly.sites.argo.cloud=https://arpi.afroditi.hellasgrid.gr:443/api/v2/grou
 # GOC DB
 ######################
 
-goc.siteList=https://goc.egi.eu/gocdbpi/private/?method=get_site&certification_status=Certified&production_status=Production
-goc.ngiContactsList=https://goc.egi.eu/gocdbpi/private/?method=get_roc_contacts
-goc.serviceFlavours=https://goc.egi.eu/gocdbpi/public/?method=get_service_types
-goc.hostList=https://goc.egi.eu/gocdbpi/public/?method=get_service
+goc.siteList=https://creg.eudat.eu/gocdbpi/private/?method=get_site&production_status=Production&certification_status=Candidate
+goc.ngiContactsList=https://creg.eudat.eu/gocdbpi/private/?method=get_roc_contacts
+goc.serviceFlavours=https://creg.eudat.eu/gocdbpi/public/?method=get_service_types
+goc.hostList=https://creg.eudat.eu/gocdbpi/public/?method=get_service


### PR DESCRIPTION
With this PR the eudat pilot uses the corresponding gocdb pi to reference sites. A simple verification is available [here](pilot instance). 
