### PR TITLE
ARGO-364 Modify results conditionally if one or more projects are queried

### DIFF
--- a/etc/views/ar.xml
+++ b/etc/views/ar.xml
@@ -223,11 +223,24 @@
                 <attribute-create out="view">site_ar</attribute-create>
                 <attribute-create out="view_details">$view_details</attribute-create>
 
-                <element in="group" if="@name=$ngi or $ngi='false'">
-                    <element in="group" out="Site" if="contains(concat($site,','),@name) or $ngi!='false'">
+                <!-- single project for results page -->
+                <element in="group" if="(@name=$ngi or $ngi='false') and contains($site,',')=false">
+                    <element in="group" out="Site" if="$site=@name or $ngi!='false'">
+                        <element in="results" out="Availability"></element>
+                    </element>                    
+                </element>
+                <!-- single project from custom form -->
+                <element in="group" if="(@name=$ngi or $ngi='false') and substring-after($site,',')=' '">
+                    <element in="group" out="Site" if="substring-before($site,',')=@name or $ngi!='false'">
                         <element in="results" out="Availability"></element>
                     </element>                    
                 </element>    
+                <!-- multiple projects -->
+                <element in="group" if="(@name=$ngi or $ngi='false') and contains(substring-after($site,','),',')">
+                    <element in="group" out="Site" if="contains($site,@name) or $ngi!='false'">
+                        <element in="results" out="Availability"></element>
+                    </element>                    
+                </element>
                 <element-ignore></element-ignore>                
             </element>
             
@@ -455,3 +468,4 @@
 
 
 </config>
+

--- a/etc/views/status.xml
+++ b/etc/views/status.xml
@@ -84,7 +84,12 @@
                 <attribute-create out="view">'status_report-sf'</attribute-create>
                 <attribute-create out="ngi" if="$ngi!='all'">$ngi</attribute-create>
 
-                <element in="group" if="contains(concat($site,','),@name) or $site='false'">
+                <!-- single project -->
+                <element in="group" if="(substring-after($site,',')=' ' and substring-before($site,',')=@name) or $site='false'">
+                    <attribute-create out="group">$SiteList/results/Ngi[SITE/@NAME=current()/../@name]/@key</attribute-create>
+                </element>
+                <!-- multiple projects -->
+                <element in="group" if="contains(substring-after($site,','),',') and contains($site,@name)">
                     <attribute-create out="group">$SiteList/results/Ngi[SITE/@NAME=current()/../@name]/@key</attribute-create>
                 </element>
                 <element-ignore></element-ignore>


### PR DESCRIPTION
# Description

Within custom form result views the `contains` XPath function is used to filter projects based on the query term. This PR uses a direct equality filter in case only one search term is being used for both ar and status custom forms. 

please review /cc @themiszamani 
